### PR TITLE
fix(rod-stats): recover orphan rod ids and update catch count correctly

### DIFF
--- a/src/main/java/com/kunfury/blepfishing/database/tables/RodTable.java
+++ b/src/main/java/com/kunfury/blepfishing/database/tables/RodTable.java
@@ -46,14 +46,15 @@ public class RodTable extends DbTable<FishingRod> {
             ResultSet resultSet = preparedStatement.executeQuery();
 
             if(!resultSet.next()){
-                Bukkit.getLogger().warning("Tried to get invalid Tournament with ID: " + id);
+                Bukkit.getLogger().warning("Tried to get invalid FishingRod with ID: " + id);
                 return null;
             }
 
             PreparedStatement caughtStatement = connection.prepareStatement("""
-                    SELECT COUNT(*) AS haul FROM fish JOIN fishingRods
-                    ON (fish.rodId = fishingRods.Id)
+                    SELECT COUNT(*) AS haul FROM fish
+                    WHERE rodId = ?
                     """);
+            caughtStatement.setInt(1, id);
 
             ResultSet rs = caughtStatement.executeQuery();
             rs.next();

--- a/src/main/java/com/kunfury/blepfishing/listeners/FishingListener.java
+++ b/src/main/java/com/kunfury/blepfishing/listeners/FishingListener.java
@@ -96,6 +96,7 @@ public class FishingListener implements Listener {
         Integer rodId = GetRodId(player);
 
         FishObject caughtFish = fishType.GenerateFish(rarity, e.getPlayer().getUniqueId(), rodId, allBlue);
+        UpdateHeldRodStats(player, rodId);
 
         FishBag fishBag = FishBag.GetBag(player);
         if(fishBag != null){
@@ -218,6 +219,11 @@ public class FishingListener implements Listener {
         if(ItemHandler.hasTag(rodItem, ItemHandler.FishRodId)){
             int rodId = ItemHandler.getTagInt(rodItem, ItemHandler.FishRodId);
             fishingRod = Database.Rods.Get(rodId);
+            if(fishingRod == null){
+                Bukkit.getLogger().warning(Formatting.GetMessagePrefix() + "Found orphaned fishing rod tag for " + player.getName()
+                        + " (rodId=" + rodId + "). Reinitializing rod metadata.");
+                fishingRod = FishingRod.InitialSetup(rodItem, player);
+            }
         }else
             fishingRod = FishingRod.InitialSetup(rodItem, player);
 
@@ -228,5 +234,29 @@ public class FishingListener implements Listener {
         }
         fishingRod.UpdateRodItem(rodItem);
         return fishingRod.Id;
+    }
+
+    private void UpdateHeldRodStats(Player player, Integer rodId){
+        if(rodId == null)
+            return;
+
+        FishingRod fishingRod = Database.Rods.Get(rodId);
+        if(fishingRod == null)
+            return;
+
+        PlayerInventory pInv = player.getInventory();
+        ItemStack mainHand = pInv.getItemInMainHand();
+        ItemStack offHand = pInv.getItemInOffHand();
+
+        if(mainHand.getType() == Material.FISHING_ROD && ItemHandler.hasTag(mainHand, ItemHandler.FishRodId)
+                && ItemHandler.getTagInt(mainHand, ItemHandler.FishRodId) == rodId){
+            fishingRod.UpdateRodItem(mainHand);
+            return;
+        }
+
+        if(offHand.getType() == Material.FISHING_ROD && ItemHandler.hasTag(offHand, ItemHandler.FishRodId)
+                && ItemHandler.getTagInt(offHand, ItemHandler.FishRodId) == rodId){
+            fishingRod.UpdateRodItem(offHand);
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes fishing rod stat tracking issues when rod metadata becomes desynced from the database.

## Problems addressed
1. Orphan rod IDs could cause `Null fishing rod` errors.
2. Rod catch count query was not filtering by rod ID, causing incorrect totals.
3. Rod lore/stat updates could appear delayed by one catch.
4. Log message referenced “Tournament” instead of “FishingRod” in rod lookup path.

## Changes
- Added recovery path in `FishingListener`:
  - If a rod has `FishRodId` but DB lookup fails, the rod is reinitialized automatically.
  - Added warning log explaining orphan rod tag recovery.
- Fixed rod catch count SQL in `RodTable`:
  - Now counts fish with `WHERE rodId = ?`.
- Added immediate rod stat refresh after fish creation:
  - Updates held rod lore with the latest count in the same catch flow.
- Corrected misleading warning message text in `RodTable`.

## Expected behavior after this PR
- Old/desynced rods no longer fail with `Null fishing rod`.
- Rod stats are accurate per rod.
- Catch count updates are reflected immediately after each catch.
- Logs are clearer for debugging.

## Notes
- No gameplay mechanics changed.
- This is a stability/data-consistency fix for rod metadata and stats tracking.
